### PR TITLE
fix: Get "Send to ControlNet" working again by updating depth_sendImage() (plus general linting)

### DIFF
--- a/javascript/main.js
+++ b/javascript/main.js
@@ -25,16 +25,16 @@ function depth_gradioApp() {
     return root;
 }
 
-function depth_calcResolution(resolution){
+function depth_calcResolution(resolution) {
     const width = resolution[0]
     const height = resolution[1]
     const viewportWidth = window.innerWidth / 2.25;
     const viewportHeight = window.innerHeight * 0.75;
     const ratio = Math.min(viewportWidth / width, viewportHeight / height);
-    return {width: width * ratio, height: height * ratio}
+    return { width: width * ratio, height: height * ratio }
 }
 
-function depth_resizeCanvas(width, height){
+function depth_resizeCanvas(width, height) {
     const elem = depth_lib_elem;
 
     let resolution = depth_calcResolution([width, height])
@@ -49,19 +49,19 @@ function depth_resizeCanvas(width, height){
     elem.parentElement.style.height = resolution["height"] + "px"
 }
 
-function depth_addImg(path){
-	fabric.Image.fromURL(path, function(oImg) {
-		depth_lib_canvas.add(oImg);
-		depth_lib_canvas.discardActiveObject();
-		depth_lib_canvas.setActiveObject(oImg);
+function depth_addImg(path) {
+    fabric.Image.fromURL(path, function (oImg) {
+        depth_lib_canvas.add(oImg);
+        depth_lib_canvas.discardActiveObject();
+        depth_lib_canvas.setActiveObject(oImg);
         oImg.set({
             opacity: depth_addOpacity
         });
-	});
-	depth_lib_canvas.requestRenderAll();
+    });
+    depth_lib_canvas.requestRenderAll();
 }
 
-function depth_initCanvas(elem){
+function depth_initCanvas(elem) {
     window.depth_lib_canvas = new fabric.Canvas(elem, {
         backgroundColor: '#000',
         // selection: false,
@@ -70,16 +70,16 @@ function depth_initCanvas(elem){
 
     window.depth_lib_elem = elem
 
-    
+
     depth_resizeCanvas(...depth_obj.resolution)
 }
 
-function depth_resetCanvas(){
+function depth_resetCanvas() {
     depth_lib_canvas.clear();
     depth_lib_canvas.backgroundColor = depth_bgColor;
 }
 
-function depth_savePNG(){
+function depth_savePNG() {
     if (depth_lib_canvas.backgroundImage) depth_lib_canvas.backgroundImage.opacity = 0
     depth_lib_canvas.discardActiveObject();
     depth_lib_canvas.renderAll()
@@ -95,20 +95,20 @@ function depth_savePNG(){
     return
 }
 
-function depth_addBackground(){
+function depth_addBackground() {
     const input = document.createElement("input");
     input.type = "file"
     input.accept = "image/*"
-    input.addEventListener("change", function(e){
+    input.addEventListener("change", function (e) {
         const file = e.target.files[0];
-		var fileReader = new FileReader();
-		fileReader.onload = function() {
-			var dataUri = this.result;
+        var fileReader = new FileReader();
+        fileReader.onload = function () {
+            var dataUri = this.result;
             depth_lib_canvas.setBackgroundImage(dataUri, depth_lib_canvas.renderAll.bind(depth_lib_canvas), {
                 opacity: 0.5
             });
-		}
-		fileReader.readAsDataURL(file);
+        }
+        fileReader.readAsDataURL(file);
     })
     input.click()
 }
@@ -117,28 +117,47 @@ function depth_removeBackground() {
     depth_lib_canvas.setBackgroundImage(0, depth_lib_canvas.renderAll.bind(depth_lib_canvas));
 }
 
-function depth_sendImage(){
-    if (depth_lib_canvas.backgroundImage) depth_lib_canvas.backgroundImage.opacity = 0
+function depth_sendImage() {
+    if (depth_lib_canvas.backgroundImage) depth_lib_canvas.backgroundImage.opacity = 0;
     depth_lib_canvas.discardActiveObject();
-    depth_lib_canvas.renderAll()
-    depth_lib_elem.toBlob((blob) => {
-        const file = new File(([blob]), "pose.png")
+    depth_lib_canvas.renderAll();
+    depth_lib_elem.toBlob(async (blob) => {
+        const file = new File(([blob]), "pose.png");
         const dt = new DataTransfer();
         dt.items.add(file);
-        const list = dt.files
-        depth_gradioApp().querySelector("#txt2img_script_container").querySelectorAll("span.transition").forEach((elem) => {
-            if (elem.previousElementSibling.textContent === "ControlNet"){
-                switch_to_txt2img()
-                elem.className.includes("rotate-90") && elem.parentElement.click();
-                const input = elem.parentElement.parentElement.querySelector("input[type='file']");
-                const button = elem.parentElement.parentElement.querySelector("button[aria-label='Clear']")
-                button && button.click();
-                input.value = "";
-                input.files = list;
-                const event = new Event('change', { 'bubbles': true, "composed": true });
-                input.dispatchEvent(event);
+        const list = dt.files;
+
+        const divControlNet = depth_gradioApp().querySelector("#txt2img_controlnet");
+        if (divControlNet) {
+            switch_to_txt2img();
+
+            // open the ControlNet accordion if it's not already open
+            // but give up if it takes longer than 5 secs
+            labelControlNet = divControlNet.querySelector("div.label-wrap");
+            if (!labelControlNet.classList.contains("open")) {
+                labelControlNet.click();
+                let waitUntilHasClassOpenCount = 0;
+                const waitUntilHasClassOpen = async () => {
+                    waitUntilHasClassOpenCount++;
+                    if (waitUntilHasClassOpenCount > 50) {
+                        return false;
+                    } else if (labelControlNet.classList.contains("open")) {
+                        return true;
+                    } else {
+                        setTimeout(() => waitUntilHasClassOpen(), 100)
+                    }
+                };
+                await waitUntilHasClassOpen();
             }
-        })
+
+            const input = divControlNet.querySelector("input[type='file']");
+            const button = divControlNet.querySelector("button[aria-label='Clear']")
+            button && button.click();
+            input.value = "";
+            input.files = list;
+            const event = new Event('change', { 'bubbles': true, "composed": true });
+            input.dispatchEvent(event);
+        }
     });
     if (depth_lib_canvas.backgroundImage) depth_lib_canvas.backgroundImage.opacity = 0.5
     depth_lib_canvas.renderAll()
@@ -170,7 +189,7 @@ function depth_removeSelection() {
 
 window.addEventListener('DOMContentLoaded', () => {
     const observer = new MutationObserver((m) => {
-        if(!depth_executed && depth_gradioApp().querySelector('#depth_lib_canvas')){
+        if (!depth_executed && depth_gradioApp().querySelector('#depth_lib_canvas')) {
             depth_executed = true;
             depth_initCanvas(depth_gradioApp().querySelector('#depth_lib_canvas'))
             // depth_gradioApp().querySelectorAll("#tabs > div > button").forEach((elem) => {


### PR DESCRIPTION
"Send to ControlNet" has been broken for a while due to the Gradio change in A1111.

This PR updates the `main.js` Javascript file so that it works again.

Plus I've also linted it as part of a general tidying up.

Related to issue #21 